### PR TITLE
11/12g support for nullable/uninitialized values.

### DIFF
--- a/oci_aq.c
+++ b/oci_aq.c
@@ -109,7 +109,6 @@ value caml_oci_flt_from_number(value handles, value cht, value offset) {
   c_alloc_t t = C_alloc_val(cht);
   int o = Int_val(offset);
 
-  //OCINumber* on = (OCINumber*)malloc(sizeof(OCINumber));
   OCINumber on;
   memcpy(&on, &t.ptr + o, sizeof(OCINumber));
   double test;

--- a/oci_select.c
+++ b/oci_select.c
@@ -90,7 +90,7 @@ static struct custom_operations oci_defhandle_custom_ops = {"oci_defhandle_custo
 value caml_oci_define(value handles, value stmt, value pos, value dtype, value size) {
   CAMLparam5(handles, stmt, pos, dtype, size);
   CAMLlocal1(r);
-  r = caml_alloc_tuple(3);
+  r = caml_alloc_tuple(4);
   oci_handles_t h = Oci_handles_val(handles);
   OCIStmt* sth = Oci_statement_val(stmt);
   int p = Int_val(pos); /* C and OCaml count from 0, Oracle counts from 1 */
@@ -103,7 +103,7 @@ value caml_oci_define(value handles, value stmt, value pos, value dtype, value s
   oci_define_t defs = { NULL, NULL, 0, 0.0, 0 };
   defs.dtype = dtype;
 
-  sword x;
+  sword x = -1;
   
 #ifdef DEBUG
   char dbuf[256]; snprintf(dbuf, 255, "caml_oci_define: defining for pos=%d dtype=%d is_int=%d size=%d", p + 1, t, ii, s); debug(dbuf);
@@ -134,7 +134,9 @@ value caml_oci_define(value handles, value stmt, value pos, value dtype, value s
   
   Store_field(r, 0, Val_int(t));
   Store_field(r, 1, Val_bool(ii));
-  Store_field(r, 2, v);
+  int is_null = defs.ind < 0;
+  Store_field(r, 2, Val_bool(is_null));
+  Store_field(r, 3, v);
 
   CAMLreturn(r);
 }

--- a/oci_types.c
+++ b/oci_types.c
@@ -97,5 +97,4 @@ value caml_oci_get_int(value handles, value defs) {
   CAMLreturn(Val_int(r));
 }
 
-
 /* end of file */

--- a/opam
+++ b/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+name: "ociml"
+version: "dev"
+author : "Gauis Hammond, Carmelo Piccione carmelo.piccione+ociml@gmail.com"
+maintainer: "carmelo.piccione+ociml@gmail.com"
+homepage: "https://github.com/gauistech/ociml"
+dev-repo: "git://github.com/gaiustech/ociml.git"
+bug-reports: "https://github.com/gaiustech/ociml/issues"
+
+build: [
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+ ["ocamlfind" "remove" "ociml"]
+]
+
+depends: [
+]


### PR DESCRIPTION
This makes some tweaks to handle null or uninitialized values for both 11/12g oracle clients. Without this change, the code either throws an exception (11g) or returns garbage values when a column is actually null (12g).

 