### PR TITLE
remove unnecessary unix.cma linking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ shell: all
 	ocamlmktop -g -custom -o ocimlsh $(CCLIBS) unix.cma $(MLOBJS) $(COBJS)
 
 ociml.cma:	$(MLOBJS) $(COBJS)
-	ocamlmklib -verbose -o ociml -L$(ORACLE_HOME)/lib -lclntsh -cclib -lclntsh unix.cma $(MLOBJS) $(COBJS)
+	ocamlmklib -verbose -o ociml -L$(ORACLE_HOME)/lib -lclntsh -cclib -lclntsh $(MLOBJS) $(COBJS)
 
 ociml.cmxa:	$(MLOPTOBJS) $(COBJS)
 	ocamlmklib -verbose -o ociml -L$(ORACLE_HOME)/lib -lclntsh -cclib -lclntsh $(MLOPTOBJS) $(COBJS)


### PR DESCRIPTION
This removes an unnecessary linking of ```unix.cma```. Without this change you'll occasionally see that the unix module appears twice and one is warned about it. It also ends up breaking ocamlscript native compilation, which is how I discovered this in the first place.
 
